### PR TITLE
enum_help導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ gem 'devise'
 gem 'kaminari','~> 1.2.1'
 
 gem 'pry-rails'
+
+gem "enum_help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.12.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -260,6 +262,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  enum_help
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari (~> 1.2.1)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,10 @@
 class Order < ApplicationRecord
+  
+  
+  
+  
+  
+  enum payment_method: { transfer: 0, credit_card: 1 }
+  enum order_status: { waiting: 0, verification: 1, producing: 2, preparing: 3,shipped: 4 }
+  
 end

--- a/app/models/orderd_product.rb
+++ b/app/models/orderd_product.rb
@@ -1,2 +1,10 @@
 class OrderdProduct < ApplicationRecord
+  
+  
+  
+  
+  
+  enum order_details: { no_product: 0, waiting: 1, producing: 2, producted: 3 }
+  
+  
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module NaganoCake
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,18 @@
+  ja:
+    enums:
+      order:
+        payment_method:
+          transfer: "銀行振込"
+          credit_card: "クレジットカード"
+        order_status:
+          waiting: "入金待ち"
+          verification: "入金確認"
+          producing: "製作中"
+          preparing: "発送準備中"
+          shipped: "発送済み"
+      orderd_product:
+        order_details:
+          no_product: "着手不可"
+          waiting: "製作待ち"
+          producing: "製作中"
+          producted: "製作完了"


### PR DESCRIPTION
カリキュラムの実装ヒントのenum導入手順を元にgem”enum_help”導入しています。
また、それに合わせて
orderモデルに支払方法・受注ステータス
orderd＿productモデルに製作ステータスのenum管理の記述追加しています。